### PR TITLE
Allow more robust relative and direct paths for dataDir

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ class Enmap extends Map {
       this.name = options.name;
       //todo: check for "unique" option for the DB name and exit if exists
       this.validateName();
-      this.dataDir = (options.dataDir || 'data');
+      this.dataDir = path.resolve(process.cwd(), (options.dataDir || 'data'));
       this.persistent = (options.persistent || false);
       if (!options.dataDir) {
         const fs = require('fs');
@@ -47,7 +47,7 @@ class Enmap extends Map {
           fs.mkdirSync('./data');
         }
       }
-      this.path = path.join(process.cwd(), this.dataDir, this.name);
+      this.path = path.join(this.dataDir, this.name);
       this.db = new level(this.path);
       this.init();
     } else {


### PR DESCRIPTION
Before, dataDir was limited to relative paths.
```
C:\workspace\NoxiousBot\data
C:\workspace\data
C:\workspace\NoxiousBot\c:\data
[2017-09-13 11:00:13] console.log(path.join(process.cwd(), 'data'));
[2017-09-13 11:00:13] console.log(path.join(process.cwd(), '../data'));
[2017-09-13 11:00:13] console.log(path.join(process.cwd(), 'c:/data'));)
```
now, it will accept all types of paths.
```
C:\workspace\NoxiousBot\data
C:\workspace\data
c:\data
[2017-09-13 10:56:02] console.log(path.resolve(process.cwd(), 'data'));
[2017-09-13 10:56:02] console.log(path.resolve(process.cwd(), '../data'));
[2017-09-13 10:56:02] console.log(path.resolve(process.cwd(), 'c:/data'));
```