### PR TITLE
sort method in the Enmap

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -417,7 +417,18 @@ class Enmap extends Map {
       return testVal !== value || (testVal === undefined && !enmap.has(key));
     });
   }
-
+  
+  /**
+   * The sort() method sorts the elements of a collection and returns it.
+   * The sort is not necessarily stable. The default sort order is according to string Unicode code points.
+   * @param {Function} [compareFunction] Specifies a function that defines the sort order.
+   * If omitted, the collection is sorted according to each character's Unicode code point value,
+   * according to the string conversion of each element.
+   * @returns {Enmap}
+   */
+  sort(compareFunction = (x, y) => +(x > y) || +(x === y) - 1) {
+    return new Enmap(Array.from(this.entries()).sort((a, b) => compareFunction(a[1], b[1], a[0], b[0])));
+  }
 }
 
 module.exports = Enmap;


### PR DESCRIPTION
It was a very useful thing for stuff such as statistics. I don't know why it got removed.