### PR TITLE
Bugfix + enhancement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,21 @@ class Enmap extends Map {
       options = iterable || {};
       iterable = null;
     }
+    
+    if (!options.name){
+     Object.defineProperty(this, 'name', {
+        value: 'MemoryEnmap',
+        writable: false,
+        enumerable: false,
+        configurable: false
+      });
+      Object.defineProperty(this, 'isReady', {
+        value: true,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      }); 
+    }
     super(iterable);
 
     let cloneLevel;
@@ -122,19 +137,6 @@ class Enmap extends Map {
       });
       this[_validateName]();
       this[_init](pool);
-    } else {
-      Object.defineProperty(this, 'name', {
-        value: 'MemoryEnmap',
-        writable: false,
-        enumerable: false,
-        configurable: false
-      });
-      Object.defineProperty(this, 'isReady', {
-        value: true,
-        writable: false,
-        enumerable: false,
-        configurable: false
-      });
     }
   }
 
@@ -1087,7 +1089,7 @@ class Enmap extends Map {
      */
   filter(fn, thisArg) {
     if (thisArg) fn = fn.bind(thisArg);
-    const results = new Enmap();
+    const results = new this.constructor();
     for (const [key, val] of this) {
       if (fn(val, key, this)) results.set(key, val);
     }


### PR DESCRIPTION
Issue:
Lets look at the following code:
```js
const Enmap = require('enmap');
const iterable = [['feature1', false], ['feature2', false], ['feature3', false]];

class Test extends Map{
  constructor(x){
    super(x);
  }
  
  set(key, value){
    throw 'This wont work';
  }
}

new Map(iterable) // No error thrown, works as expected
new Test(iterable) // Error! ‘This wont work’!
```
So how does this issue show in Enmap?
```js
const Enmap = require('enmap');
const iterable = [['feature1', false], ['feature2', false], ['feature3', false]];

const x = new Enmap(iterable) // This throws an error, because 'the database is not ready yet'
```
So what is causing this? In the constructor function, the `super()` method is called before setting `<Enmap>.ready` to true.
Solution: changing this order

Enhancement:
```js
const Enmap = require('enmap');
class SuperMap extends Enmap{
  constructor(options){
    super(options)
  }

  importentFunc(){
    return 5;
  }
}

const x = new SuperMap();
console.log(x.importentFunc()) // Logs `5` as expected
const y = x.filter(() => true).importentFunc(); // TypeError: x.filter(...).importentFunc is not a function
```
Over here, an error is thrown, because the function .filter return a new Enmap, even when extending the Enmap with your own features.
By using `new this.constructor()` instead of `new Enmap()`, nothing will change for the users that don't extend the Enmap, but for those who do, it will be a benifit.