### PR TITLE
Fixing types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -107,7 +107,7 @@ declare module 'enmap' {
          * enmap.set('ArraysToo', 2, 'three'); // changes "tree" to "three" in array.
          * @returns {Enmap} The enmap.
          */
-        set(key: key, val: any, path?: string): this;
+        public set(key: key, val: any, path?: string): this;
 
         /**
          * Retrieves a key from the enmap. If fetchAll is false, returns a promise.
@@ -121,27 +121,27 @@ declare module 'enmap' {
          * const someSubValue = enmap.get("anObjectKey", "someprop.someOtherSubProp");
          * @return {*} The value for this key.
          */
-        get(key: key, path?: string): any;
+        public get(key: key, path?: string): any;
 
         /**
          * Fetches every key from the persistent enmap and loads them into the current enmap value.
          * @return {Enmap} The enmap containing all values.
          */
-        fetchEverything(): this;
+        public fetchEverything(): this;
 
         /**
          * Force fetch one or more key values from the enmap. If the database has changed, that new value is used.
          * @param {string|number|Array<string|number>} keyOrKeys A single key or array of keys to force fetch from the enmap database.
          * @return {Enmap|*} The Enmap, including the new fetched values, or the value in case the function argument is a single key.
          */
-        fetch(keyOrKeys: keyOrKeys): this | any;
+        public fetch(keyOrKeys: keyOrKeys): this | any;
 
         /**
          * Removes a key or keys from the cache - useful when disabling autoFetch.
          * @param {string|number|Array<string|number>} keyOrArrayOfKeys A single key or array of keys to remove from the cache.
          * @returns {Enmap} The enmap minus the evicted keys.
          */
-        evict(keyOrArrayOfKeys: keyOrKeys): this;
+        public evict(keyOrArrayOfKeys: keyOrKeys): this;
 
         /**
          * Function called whenever data changes within Enmap after the initial load.
@@ -152,7 +152,7 @@ declare module 'enmap' {
          * });
          * @param {Function} cb A callback function that will be called whenever data changes in the enmap.
          */
-        changed(cb: changedFunc): void;
+        public changed(cb: changedFunc): void;
 
         /**
          * Shuts down the database. WARNING: USING THIS MAKES THE ENMAP UNUSEABLE. You should
@@ -160,7 +160,7 @@ declare module 'enmap' {
          * Note that honestly I've never had to use this, shutting down the app without a close() is fine.
          * @return {Promise<*>} The promise of the database closing operation.
          */
-        close(): Promise<void>;
+        public close(): Promise<void>;
 
         /**
          * Modify the property of a value inside the enmap, if the value is an object or array.
@@ -172,7 +172,7 @@ declare module 'enmap' {
          * @param {*} val Required. The value to apply to the specified property.
          * @returns {Enmap} The enmap.
          */
-        setProp(key: key, path: string, val: any): this;
+        public setProp(key: key, path: string, val: any): this;
 
         /**
          * Push to an array value in Enmap.
@@ -191,7 +191,7 @@ declare module 'enmap' {
          * enmap.push("arrayInObject", "five", "sub"); adds "five" at the end of the sub array
          * @returns {Enmap} The enmap.
          */
-        push(key: key, val: any, path?: string, allowDupes?: boolean): this;
+        public push(key: key, val: any, path?: string, allowDupes?: boolean): this;
 
         /**
          * Push to an array element inside an Object or Array element in Enmap.
@@ -203,7 +203,7 @@ declare module 'enmap' {
          * @param {boolean} allowDupes Allow duplicate values in the array (default: false).
          * @returns {Enmap} The enmap.
          */
-        pushIn(key: key, path: string, val: any, allowDupes?: boolean): this;
+        public pushIn(key: key, path: string, val: any, allowDupes?: boolean): this;
 
         // AWESOME MATHEMATICAL METHODS
 
@@ -226,7 +226,7 @@ declare module 'enmap' {
          *
          * @returns {Enmap} The enmap.
          */
-        math(key: key, operation: MathOps, operand: number, path?: string): this;
+        public math(key: key, operation: MathOps, operand: number, path?: string): this;
 
         /**
          * Increments a key's value or property by 1. Value must be a number, or a path to a number.
@@ -241,7 +241,7 @@ declare module 'enmap' {
          * points.inc("numberInObject", "sub.anInt"); // {sub: { anInt: 6 }}
          * @returns {Enmap} The enmap.
          */
-        inc(key: key, path?: string): this;
+        public inc(key: key, path?: string): this;
 
         /**
          * Decrements a key's value or property by 1. Value must be a number, or a path to a number.
@@ -256,7 +256,7 @@ declare module 'enmap' {
          * points.dec("numberInObject", "sub.anInt"); // {sub: { anInt: 4 }}
          * @returns {Enmap} The enmap.
          */
-        dec(key: key, path?: string): this;
+        public dec(key: key, path?: string): this;
 
         /**
          * Returns the specific property within a stored value. If the key does not exist or the value is not an object, throws an error.
@@ -265,7 +265,7 @@ declare module 'enmap' {
          * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
          * @return {*} The value of the property obtained.
          */
-        getProp(key: key, path: string): any;
+        public getProp(key: key, path: string): any;
 
         /**
          * Returns the key's value, or the default given, ensuring that the data is there.
@@ -285,7 +285,7 @@ declare module 'enmap' {
          * console.log(settings) // enmap's value for "1234567890" if it exists, otherwise the defaultSettings value.
          * @return {*} The value from the database for the key, or the default value provided for a new key.
          */
-        ensure(key: key, defaultValue: any, path?: string): any;
+        public ensure(key: key, defaultValue: any, path?: string): any;
 
         /* BOOLEAN METHODS THAT CHECKS FOR THINGS IN ENMAP */
 
@@ -303,7 +303,7 @@ declare module 'enmap' {
          * if(!enmap.has("myOtherKey", "oneProp.otherProp.SubProp")) return false;
          * @returns {boolean}
          */
-        has(key: key, path?: string): boolean;
+        public has(key: key, path?: string): boolean;
 
         /**
          * Returns whether or not the property exists within an object or array value in enmap.
@@ -312,7 +312,7 @@ declare module 'enmap' {
          * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
          * @return {boolean} Whether the property exists.
          */
-        hasProp(key: key, path: string): boolean;
+        public hasProp(key: key, path: string): boolean;
 
         /**
          * Deletes a key in the Enmap.
@@ -321,7 +321,7 @@ declare module 'enmap' {
          * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
          * @returns {Enmap} The enmap.
          */
-        delete(key: key, path?: string): this;
+        public delete(key: key, path?: string): this;
 
         /**
          * Delete a property from an object or array value in Enmap.
@@ -329,14 +329,14 @@ declare module 'enmap' {
          * @param {string} path Required. The name of the property to remove from the object.
          * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
          */
-        deleteProp(key: key, path: string): void;
+        public deleteProp(key: key, path: string): void;
 
         /**
          * Deletes everything from the enmap. If persistent, clears the database of all its data for this table.
          */
-        deleteAll(): void;
+        public deleteAll(): void;
 
-        clear(): void;
+        public clear(): void;
 
         /**
          * Remove a value in an Array or Object element in Enmap. Note that this only works for
@@ -349,7 +349,7 @@ declare module 'enmap' {
          * If not presents, removes directly from the value.
          * @returns {Enmap} The enmap.
          */
-        remove(key: key, val: any, path?: string): this;
+        public remove(key: key, val: any, path?: string): this;
 
         /**
          * Remove a value from an Array or Object property inside an Array or Object element in Enmap.
@@ -361,7 +361,7 @@ declare module 'enmap' {
          * @param {*} val Required. The value to remove from the array property.
          * @returns {Enmap} The enmap.
          */
-        removeFrom(key: key, path: string, val): this;
+        public removeFrom(key: key, path: string, val): this;
 
         /**
          * Initialize multiple Enmaps easily.
@@ -378,7 +378,7 @@ declare module 'enmap' {
          *
          * @returns {Array<Map>} An array of initialized Enmaps.
          */
-        static multi(names: string[], options?: EnmapOptions): Enmap[];
+        public static multi(names: string[], options?: EnmapOptions): Enmap[];
 
         /* INTERNAL (Private) METHODS */
 
@@ -466,7 +466,7 @@ declare module 'enmap' {
          * use `Array.from(enmap.keys())` instead.
          * @returns {Array<string | number>}
          */
-        keyArray(): key[];
+        public keyArray(): key[];
 
         /**
          * Obtains random value(s) from this Enmap. This relies on {@link Enmap#array}.
@@ -474,7 +474,7 @@ declare module 'enmap' {
          * @returns {*|Array<*>} The single value if `count` is undefined,
          * or an array of values of `count` length
          */
-        random(count?: number): any | any[];
+        public random(count?: number): any | any[];
 
         /**
          * Obtains random key(s) from this Enmap. This relies on {@link Enmap#keyArray}
@@ -482,7 +482,7 @@ declare module 'enmap' {
          * @returns {*|Array<*>} The single key if `count` is undefined,
          * or an array of keys of `count` length
          */
-        randomKey(count?: number): any | any[];
+        public randomKey(count?: number): any | any[];
 
         /**
          * Searches for all items where their specified property's value is identical to the given value
@@ -493,7 +493,7 @@ declare module 'enmap' {
          * @example
          * enmap.findAll('username', 'Bob');
          */
-        findAll(prop: string, value: any): any[];
+        public findAll(prop: string, value: any): any[];
 
         /**
          * Searches for a single item where its specified property's value is identical to the given value
@@ -510,7 +510,7 @@ declare module 'enmap' {
          * @example
          * enmap.find(val => val.username === 'Bob');
          */
-        find(propOrFn: string | findFunc, value?: any): any;
+        public find(propOrFn: string | findFunc, value?: any): any;
 
         /* eslint-disable max-len */
         /**
@@ -526,7 +526,7 @@ declare module 'enmap' {
          * enmap.findKey(val => val.username === 'Bob');
          */
         /* eslint-enable max-len */
-        findKey(propOrFn: string | findKeyFunc, value?: any): key;
+        public findKey(propOrFn: string | findKeyFunc, value?: any): key;
 
         /**
          * Searches for the existence of a single item where its specified property's value is identical to the given value
@@ -541,7 +541,7 @@ declare module 'enmap' {
          *  console.log('user here!');
          * }
          */
-        exists(prop: string, value: any): boolean;
+        public exists(prop: string, value: any): boolean;
 
         /**
          * Removes entries that satisfy the provided filter function.
@@ -549,7 +549,7 @@ declare module 'enmap' {
          * @param {Object} [thisArg] Value to use as `this` when executing function
          * @returns {number} The number of removed entries
          */
-        sweep(fn: sweepFunc, thisArg?: any): number;
+        public sweep(fn: sweepFunc, thisArg?: any): number;
 
         /**
          * Identical to
@@ -559,7 +559,7 @@ declare module 'enmap' {
          * @param {Object} [thisArg] Value to use as `this` when executing function
          * @returns {Enmap}
          */
-        filter(fn: filterFunc, thisArg?: any): Enmap;
+        public filter(fn: filterFunc, thisArg?: any): Enmap;
 
         /**
          * Identical to
@@ -568,7 +568,7 @@ declare module 'enmap' {
          * @param {Object} [thisArg] Value to use as `this` when executing function
          * @returns {Array}
          */
-        filterArray(fn: filterFunc, thisArg?: any): any[];
+        public filterArray(fn: filterFunc, thisArg?: any): any[];
 
         /**
          * Partitions the collection into two collections where the first collection
@@ -578,7 +578,7 @@ declare module 'enmap' {
          * @returns {Collection[]}
          * @example const [big, small] = collection.partition(guild => guild.memberCount > 250);
          */
-        partition(fn: partitionFunc, thisArg?: any): [Enmap, Enmap];
+        public partition(fn: partitionFunc, thisArg?: any): [Enmap, Enmap];
 
         /**
          * Identical to
@@ -587,7 +587,7 @@ declare module 'enmap' {
          * @param {*} [thisArg] Value to use as `this` when executing function
          * @returns {Array}
          */
-        map(fn: mapFunc, thisArg?: any): any[];
+        public map(fn: mapFunc, thisArg?: any): any[];
 
         /**
          * Identical to
@@ -596,7 +596,7 @@ declare module 'enmap' {
          * @param {Object} [thisArg] Value to use as `this` when executing function
          * @returns {boolean}
          */
-        some(fn: someFunc, thisArg?: any): boolean;
+        public some(fn: someFunc, thisArg?: any): boolean;
 
         /**
          * Identical to
@@ -605,7 +605,7 @@ declare module 'enmap' {
          * @param {Object} [thisArg] Value to use as `this` when executing function
          * @returns {boolean}
          */
-        every(fn: everyFunc, thisArg?: any): boolean;
+        public every(fn: everyFunc, thisArg?: any): boolean;
 
         /**
          * Identical to
@@ -615,14 +615,14 @@ declare module 'enmap' {
          * @param {*} [initialValue] Starting value for the accumulator
          * @returns {*}
          */
-        reduce(fn: reduceFunc, initialValue: any): any;
+        public reduce(fn: reduceFunc, initialValue: any): any;
 
         /**
          * Creates an identical shallow copy of this Enmap.
          * @returns {Enmap}
          * @example const newColl = someColl.clone();
          */
-        clone(): Enmap;
+        public clone(): Enmap;
 
         /**
          * Combines this Enmap with others into a new Enmap. None of the source Enmaps are modified.
@@ -630,7 +630,7 @@ declare module 'enmap' {
          * @returns {Enmap}
          * @example const newColl = someColl.concat(someOtherColl, anotherColl, ohBoyAColl);
          */
-        concat(...enmaps: Enmap[]): Enmap;
+        public concat(...enmaps: Enmap[]): Enmap;
 
         /**
          * Checks if this Enmap shares identical key-value pairings with another.
@@ -639,6 +639,6 @@ declare module 'enmap' {
          * @param {Enmap} enmap Enmap to compare with
          * @returns {boolean} Whether the Enmaps have identical contents
          */
-        equals(enmap: Enmap): boolean;
+        public equals(enmap: Enmap): boolean;
     }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,147 +6,452 @@ declare module 'enmap' {
      */
     export = Enmap;
 
-    type PropOrFun = (val: any, key: string | number, thisArg: Enmap) => any;
-    type filterFunc = (val: any, key: string | number, thisArg: Enmap) => boolean;
-    type someFunc = (val: any, key: string | number, thisArg: Enmap) => boolean;
-    type everyFunc = (val: any, key: string | number, thisArg: Enmap) => boolean;
-    type mapFunc = (val: any, key: string | number, thisArg: Enmap) => any;
+    type key = string | number;
+    type keyOrKeys = key | key[];
+
+    type ValKeyEnmapFunc = (val: any, key: key, enamp: Enmap) => boolean;
+    type findFunc = ValKeyEnmapFunc;
+    type findKeyFunc = ValKeyEnmapFunc;
+    type sweepFunc = ValKeyEnmapFunc;
+    type partitionFunc = ValKeyEnmapFunc;
+    type filterFunc = ValKeyEnmapFunc;
+    type someFunc = ValKeyEnmapFunc;
+    type everyFunc = ValKeyEnmapFunc;
+
+    type mapFunc = (val: any, key: key, enamp: Enmap) => any;
+    type changedFunc = (key: key, oldValue: any, newValue: any) => void;
     type reduceFunc = (
         accumulator: any,
         currentValue: any,
-        currentKey: string | number,
-        thisArg: Enmap
+        currentKey: key,
+        enmap: Enmap
     ) => any;
 
+    type EnmapOptions = {
+        name?: string,
+        fetchAll?: boolean,
+        autoFetch?: boolean,
+        dataDir?: string,
+        cloneLevel?: 'none' | 'shallow' | 'deep',
+        polling?: boolean,
+        pollingInterval?: number
+    }
+
+    type MathOps =  'add'   | 'addition'    | '+' |
+                    'sub'   | 'subtract'    | '-' |
+                    'mult'  | 'multiply'    | '*' |
+                    'div'   | 'divide'      | '/' |
+                    'exp'   | 'exponent'    | '^' |
+                    'mod'   | 'modulo'      | '%' ;
+
     class Enmap extends Map {
+        public readonly cloneLevel: 'none' | 'shallow' | 'deep';
+        public readonly name: string;
+        public readonly dataDir: string;
+        public readonly fetchAll: boolean;
+        public readonly autoFetch: boolean;
+        public readonly defer: Promise<void>;
+        public readonly persistent: boolean;
+        public readonly pollingInterval: number;
+        public readonly polling: boolean;
+        public readonly isReady: boolean;
+        public readonly lastSync: Date;
+        public readonly changedCB: changedFunc;
+
+        private db: any;
+        private pool: any;
+        private ready: () => void;
+
         /**
-         * Initialize multiple Enmaps easily.
-         * @param {Array<string>} names Array of strings. Each array entry will create a separate enmap with that name.
-         * @param {EnmapProvider} Provider Valid EnmapProvider object.
-         * @param {Object} options Options object to pass to the provider. See provider documentation for its options.
-         * @returns {Array<Map>} An array of initialized Enmaps.
+         * Retrieves the number of rows in the database for this enmap, even if they aren't fetched.
+         * @return {integer} The number of rows in the database.
          */
-        public static multi(names: string[], Provider: any, options?: any): Enmap[];
-
-        public fetchAll: boolean;
-
-        private db: object;
-        private defer: boolean;
-        private persistent: boolean;
-
-        constructor(iterable?: Iterable<any> | { provider: any }, options?: any);
+        public readonly count: number;
 
         /**
-         * Shuts down the underlying persistent enmap database.
+         * Retrieves all the indexes (keys) in the database for this enmap, even if they aren't fetched.
+         * @return {array<string>} Array of all indexes (keys) in the enmap, cached or not.
          */
-        public close(): void;
+        public readonly indexes: string[];
+
+        /**
+         * Generates an automatic numerical key for inserting a new value.
+         * This is a "weak" method, it ensures the value isn't duplicated, but does not
+         * guarantee it's sequential (if a value is deleted, another can take its place).
+         * Useful for logging, but not much else.
+         * @example
+         * enmap.set(enmap.autonum(), "This is a new value");
+         * @return {number} The generated key number.
+         */
+        public readonly autonum: number;
+
+        constructor(iterable?: Iterable<any> | EnmapOptions, options?: EnmapOptions);
+
+        /**
+         * Sets a value in Enmap.
+         * @param {string|number} key Required. The key of the element to add to The Enmap.
+         * @param {*} val Required. The value of the element to add to The Enmap.
+         * If the Enmap is persistent this value MUST be stringifiable as JSON.
+         * @param {string} path Optional. The path to the property to modify inside the value object or array.
+         * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
+         * @example
+         * // Direct Value Examples
+         * enmap.set('simplevalue', 'this is a string');
+         * enmap.set('isEnmapGreat', true);
+         * enmap.set('TheAnswer', 42);
+         * enmap.set('IhazObjects', { color: 'black', action: 'paint', desire: true });
+         * enmap.set('ArraysToo', [1, "two", "tree", "foor"])
+         *
+         * // Settings Properties
+         * enmap.set('IhazObjects', 'color', 'blue'); //modified previous object
+         * enmap.set('ArraysToo', 2, 'three'); // changes "tree" to "three" in array.
+         * @returns {Enmap} The enmap.
+         */
+        set(key: key, val: any, path?: string): this;
 
         /**
          * Retrieves a key from the enmap. If fetchAll is false, returns a promise.
          * @param {string|number} key The key to retrieve from the enmap.
-         * @return {*|Promise<*>} The value or a promise containing the value.
+         * @param {string} path Optional. The property to retrieve from the object or array.
+         * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
+         * @example
+         * const myKeyValue = enmap.get("myKey");
+         * console.log(myKeyValue);
+         *
+         * const someSubValue = enmap.get("anObjectKey", "someprop.someOtherSubProp");
+         * @return {*} The value for this key.
          */
-        public get(key: string | number): any | Promise<any>;
-
-        /**
-         * Force fetch one or more key values from the enmap. If the database has changed, that new value is used.
-         * @param {string|number} keyOrKeys A single key or array of keys to force fetch from the enmap database.
-         * @return {*|Map} A single value if requested, or a non-persistent enmap of keys if an array is requested.
-         */
-        public fetch(
-            keyOrKeys: string | number | Array<string | number>
-        ): any | Enmap;
+        get(key: key, path?: string): any;
 
         /**
          * Fetches every key from the persistent enmap and loads them into the current enmap value.
-         * @return {Map} The enmap containing all values.
+         * @return {Enmap} The enmap containing all values.
          */
-        public fetchEverything(): this;
+        fetchEverything(): this;
 
         /**
-         * Set the value in Enmap.
-         * @param {string|number} key Required. The key of the element to add to The Enmap.
-         * If the Enmap is persistent this value MUST be a string or number.
-         * @param {*} val Required. The value of the element to add to The Enmap.
-         * If the Enmap is persistent this value MUST be stringifiable as JSON.
-         * @return {Enmap} The Enmap.
+         * Force fetch one or more key values from the enmap. If the database has changed, that new value is used.
+         * @param {string|number|Array<string|number>} keyOrKeys A single key or array of keys to force fetch from the enmap database.
+         * @return {Enmap|*} The Enmap, including the new fetched values, or the value in case the function argument is a single key.
          */
-        public set(key: string | number, val: any): this;
+        fetch(keyOrKeys: keyOrKeys): this | any;
 
         /**
-         * Set the value in Enmap, but returns a promise that resolves once writte to the database.
-         * Useless on non-persistent Enmaps.
-         * @param {string|number} key Required. The key of the element to add to The Enmap.
-         * If the Enmap is persistent this value MUST be a string or number.
-         * @param {*} val Required. The value of the element to add to The Enmap.
-         * If the Enmap is persistent this value MUST be stringifiable as JSON.
-         * @return {Promise<Map>} The Enmap.
+         * Removes a key or keys from the cache - useful when disabling autoFetch.
+         * @param {string|number|Array<string|number>} keyOrArrayOfKeys A single key or array of keys to remove from the cache.
+         * @returns {Enmap} The enmap minus the evicted keys.
          */
-        public setAsync(key: string | number, val: any): Promise<this>;
+        evict(keyOrArrayOfKeys: keyOrKeys): this;
 
         /**
-         * Returns the specific property within a stored value. If the value isn't an object or array,
-         * returns the unchanged data If the key does not exist or the value is not an object, throws an error.
-         * @param {string|number} key Required. The key of the element to get from The Enmap.
-         * @param {*} prop Required. The property to retrieve from the object or array.
-         * @return {*} The value of the property obtained.
+         * Function called whenever data changes within Enmap after the initial load.
+         * Can be used to detect if another part of your code changed a value in enmap and react on it.
+         * @example
+         * enmap.changed((keyName, oldValue, newValue) => {
+         *   console.log(`Value of ${keyName} has changed from: \n${oldValue}\nto\n${newValue});
+         * });
+         * @param {Function} cb A callback function that will be called whenever data changes in the enmap.
          */
-        public getProp(key: string | number, prop: any): any;
+        changed(cb: changedFunc): void;
+
+        /**
+         * Shuts down the database. WARNING: USING THIS MAKES THE ENMAP UNUSEABLE. You should
+         * only use this method if you are closing your entire application.
+         * Note that honestly I've never had to use this, shutting down the app without a close() is fine.
+         * @return {Promise<*>} The promise of the database closing operation.
+         */
+        close(): Promise<void>;
 
         /**
          * Modify the property of a value inside the enmap, if the value is an object or array.
          * This is a shortcut to loading the key, changing the value, and setting it back.
          * @param {string|number} key Required. The key of the element to add to The Enmap or array.
          * This value MUST be a string or number.
-         * @param {*} prop Required. The property to modify inside the value object or array.
+         * @param {string} path Required. The property to modify inside the value object or array.
+         * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
          * @param {*} val Required. The value to apply to the specified property.
-         * @param {boolean} save Optional. Whether to save to persistent DB (used as false in init)
-         * @return {Map} The EnMap.
+         * @returns {Enmap} The enmap.
          */
-        public setProp(key: string | number, prop: any, val: any): this;
+        setProp(key: key, path: string, val: any): this;
+
+        /**
+         * Push to an array value in Enmap.
+         * @param {string|number} key Required. The key of the array element to push to in Enmap.
+         * This value MUST be a string or number.
+         * @param {*} val Required. The value to push to the array.
+         * @param {string} path Optional. The path to the property to modify inside the value object or array.
+         * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
+         * @param {boolean} allowDupes Optional. Allow duplicate values in the array (default: false).
+         * @example
+         * // Assuming
+         * enmap.set("simpleArray", [1, 2, 3, 4]);
+         * enmap.set("arrayInObject", {sub: [1, 2, 3, 4]});
+         *
+         * enmap.push("simpleArray", 5); // adds 5 at the end of the array
+         * enmap.push("arrayInObject", "five", "sub"); adds "five" at the end of the sub array
+         * @returns {Enmap} The enmap.
+         */
+        push(key: key, val: any, path?: string, allowDupes?: boolean): this;
+
+        /**
+         * Push to an array element inside an Object or Array element in Enmap.
+         * @param {string|number} key Required. The key of the element.
+         * This value MUST be a string or number.
+         * @param {string} path Required. The name of the array property to push to.
+         * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
+         * @param {*} val Required. The value push to the array property.
+         * @param {boolean} allowDupes Allow duplicate values in the array (default: false).
+         * @returns {Enmap} The enmap.
+         */
+        pushIn(key: key, path: string, val: any, allowDupes?: boolean): this;
+
+        // AWESOME MATHEMATICAL METHODS
+
+        /**
+         * Executes a mathematical operation on a value and saves it in the enmap.
+         * @param {string|number} key The enmap key on which to execute the math operation.
+         * @param {string} operation Which mathematical operation to execute. Supports most
+         * math ops: =, -, *, /, %, ^, and english spelling of those operations.
+         * @param {number} operand The right operand of the operation.
+         * @param {string} path Optional. The property path to execute the operation on, if the value is an object or array.
+         * @example
+         * // Assuming
+         * points.set("number", 42);
+         * points.set("numberInObject", {sub: { anInt: 5 }});
+         *
+         * points.math("number", "/", 2); // 21
+         * points.math("number", "add", 5); // 26
+         * points.math("number", "modulo", 3); // 2
+         * points.math("numberInObject", "+", 10, "sub.anInt");
+         *
+         * @returns {Enmap} The enmap.
+         */
+        math(key: key, operation: MathOps, operand: number, path?: string): this;
+
+        /**
+         * Increments a key's value or property by 1. Value must be a number, or a path to a number.
+         * @param {string|number} key The enmap key where the value to increment is stored.
+         * @param {string} path Optional. The property path to increment, if the value is an object or array.
+         * @example
+         * // Assuming
+         * points.set("number", 42);
+         * points.set("numberInObject", {sub: { anInt: 5 }});
+         *
+         * points.inc("number"); // 43
+         * points.inc("numberInObject", "sub.anInt"); // {sub: { anInt: 6 }}
+         * @returns {Enmap} The enmap.
+         */
+        inc(key: key, path?: string): this;
+
+        /**
+         * Decrements a key's value or property by 1. Value must be a number, or a path to a number.
+         * @param {string|number} key The enmap key where the value to decrement is stored.
+         * @param {string} path Optional. The property path to decrement, if the value is an object or array.
+         * @example
+         * // Assuming
+         * points.set("number", 42);
+         * points.set("numberInObject", {sub: { anInt: 5 }});
+         *
+         * points.dec("number"); // 41
+         * points.dec("numberInObject", "sub.anInt"); // {sub: { anInt: 4 }}
+         * @returns {Enmap} The enmap.
+         */
+        dec(key: key, path?: string): this;
+
+        /**
+         * Returns the specific property within a stored value. If the key does not exist or the value is not an object, throws an error.
+         * @param {string|number} key Required. The key of the element to get from The Enmap.
+         * @param {string} path Required. The property to retrieve from the object or array.
+         * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
+         * @return {*} The value of the property obtained.
+         */
+        getProp(key: key, path: string): any;
+
+        /**
+         * Returns the key's value, or the default given, ensuring that the data is there.
+         * This is a shortcut to "if enmap doesn't have key, set it, then get it" which is a very common pattern.
+         * @param {string|number} key Required. The key you want to make sure exists.
+         * @param {*} defaultValue Required. The value you want to save in the database and return as default.
+         * @param {string} path Optional. If presents, ensures both the key exists as an object, and the full path exists.
+         * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
+         * @example
+         * // Simply ensure the data exists (for using property methods):
+         * enmap.ensure("mykey", {some: "value", here: "as an example"});
+         * enmap.has("mykey"); // always returns true
+         * enmap.get("mykey", "here") // returns "as an example";
+         *
+         * // Get the default value back in a variable:
+         * const settings = mySettings.ensure("1234567890", defaultSettings);
+         * console.log(settings) // enmap's value for "1234567890" if it exists, otherwise the defaultSettings value.
+         * @return {*} The value from the database for the key, or the default value provided for a new key.
+         */
+        ensure(key: key, defaultValue: any, path?: string): any;
+
+        /* BOOLEAN METHODS THAT CHECKS FOR THINGS IN ENMAP */
 
         /**
          * Returns whether or not the key exists in the Enmap.
          * @param {string|number} key Required. The key of the element to add to The Enmap or array.
          * This value MUST be a string or number.
-         * @returns {Promise<boolean>}
+         * @param {string} path Optional. The property to verify inside the value object or array.
+         * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
+         * @example
+         * if(enmap.has("myKey")) {
+         *   // key is there
+         * }
+         *
+         * if(!enmap.has("myOtherKey", "oneProp.otherProp.SubProp")) return false;
+         * @returns {boolean}
          */
-        public has(key: string | number): boolean;
-        public has(key: string | number): Promise<boolean>;
+        has(key: key, path?: string): boolean;
 
         /**
          * Returns whether or not the property exists within an object or array value in enmap.
          * @param {string|number} key Required. The key of the element to check in the Enmap or array.
-         * @param {*} prop Required. The property to verify inside the value object or array.
+         * @param {*} path Required. The property to verify inside the value object or array.
+         * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
          * @return {boolean} Whether the property exists.
          */
-        public hasProp(key: string | number, prop: any): boolean;
-
-        /**
-         * Delete a property from an object or array value in Enmap.
-         * @param {string|number} key Required. The key of the element to delete the property from in Enmap.
-         * @param {*} prop Required. The name of the property to remove from the object.
-         * @returns {Promise<Enmap>|Enmap} If fetchAll is true, return the Enmap. Otherwise return a promise containing
-         * the Enmap.
-         */
-        public deleteProp(key: string | number, prop: any): Promise<this> | this;
+        hasProp(key: key, path: string): boolean;
 
         /**
          * Deletes a key in the Enmap.
          * @param {string|number} key Required. The key of the element to delete from The Enmap.
-         * @param {boolean} bulk Internal property used by the purge method.
+         * @param {string} path Optional. The name of the property to remove from the object.
+         * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
+         * @returns {Enmap} The enmap.
          */
-        public delete(key: string | number): boolean;
+        delete(key: key, path?: string): this;
 
         /**
+         * Delete a property from an object or array value in Enmap.
+         * @param {string|number} key Required. The key of the element to delete the property from in Enmap.
+         * @param {string} path Required. The name of the property to remove from the object.
+         * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
+         */
+        deleteProp(key: key, path: string): void;
+
+        /**
+         * Deletes everything from the enmap. If persistent, clears the database of all its data for this table.
+         */
+        deleteAll(): void;
+
+        clear(): void;
+
+        /**
+         * Remove a value in an Array or Object element in Enmap. Note that this only works for
+         * values, not keys. Complex values such as objects and arrays will not be removed this way.
+         * @param {string|number} key Required. The key of the element to remove from in Enmap.
+         * This value MUST be a string or number.
+         * @param {*} val Required. The value to remove from the array or object.
+         * @param {string} path Optional. The name of the array property to remove from.
+         * Can be a path with dot notation, such as "prop1.subprop2.subprop3".
+         * If not presents, removes directly from the value.
+         * @returns {Enmap} The enmap.
+         */
+        remove(key: key, val: any, path?: string): this;
+
+        /**
+         * Remove a value from an Array or Object property inside an Array or Object element in Enmap.
+         * Confusing? Sure is.
+         * @param {string|number} key Required. The key of the element.
+         * This value MUST be a string or number.
+         * @param {string} path Required. The name of the array property to remove from.
+         * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
+         * @param {*} val Required. The value to remove from the array property.
+         * @returns {Enmap} The enmap.
+         */
+        removeFrom(key: key, path: string, val): this;
+
+        /**
+         * Initialize multiple Enmaps easily.
+         * @param {Array<string>} names Array of strings. Each array entry will create a separate enmap with that name.
+         * @param {Object} options Options object to pass to the provider. See provider documentation for its options.
+         * @example
+         * // Using local variables and the mongodb provider.
+         * const Enmap = require('enmap');
+         * const { settings, tags, blacklist } = Enmap.multi(['settings', 'tags', 'blacklist']);
          *
-         * @param {string|number} key Required. The key of the element to delete from The Enmap.
-         * @param {boolean} bulk Internal property used by the purge method.
+         * // Attaching to an existing object (for instance some API's client)
+         * const Enmap = require("enmap");
+         * Object.assign(client, Enmap.multi(["settings", "tags", "blacklist"]));
+         *
+         * @returns {Array<Map>} An array of initialized Enmaps.
          */
-        public deleteAsync(key: string | number): boolean;
+        static multi(names: string[], options?: EnmapOptions): Enmap[];
+
+        /* INTERNAL (Private) METHODS */
+
+        /*
+        * Internal Method. Initializes the enmap depending on given values.
+        * @param {Map} pool In order to set data to the Enmap, one must be provided.
+        * @returns {Promise} Returns the defer promise to await the ready state.
+        */
+        private _init(pool: any): Promise<void>;
+
+        /*
+        * INTERNAL method to verify the type of a key or property
+        * Will THROW AN ERROR on wrong type, to simplify code.
+        * @param {string|number} key Required. The key of the element to check
+        * @param {string} type Required. The javascript constructor to check
+        * @param {string} path Optional. The dotProp path to the property in the object enmap.
+        */
+        private _check(key: key, type: string, path?: string): void;
+
+        /*
+        * INTERNAL method to execute a mathematical operation. Cuz... javascript.
+        * And I didn't want to import mathjs!
+        * @param {number} base the lefthand operand.
+        * @param {string} op the operation.
+        * @param {number} opand the righthand operand.
+        * @return {number} the result.
+        */
+        private _mathop(base: number, op: string, opand: number): number;
 
         /**
-         * Creates an ordered array of the values of this Enmap, and caches it internally.
+         * Internal method used to validate persistent enmap names (valid Windows filenames)
+         * @private
+         */
+        private _validateName(): void;
+
+        /*
+        * Internal Method. Verifies if a key needs to be fetched from the database.
+        * If persistent enmap and autoFetch is on, retrieves the key.
+        * @param {string|number} key The key to check or fetch.
+        */
+        private _fetchCheck(key: key, force?: boolean): void;
+
+        /*
+        * Internal Method. Parses JSON data.
+        * Reserved for future use (logical checking)
+        * @param {*} data The data to check/parse
+        * @returns {*} An object or the original data.
+        */
+        private _parseData(data: any): any;
+
+        /*
+        * Internal Method. Clones a value or object with the enmap's set clone level.
+        * @param {*} data The data to clone.
+        * @return {*} The cloned value.
+        */
+        private _clone(data: any): any;
+
+        /*
+        * Internal Method. Verifies that the database is ready, assuming persistence is used.
+        */
+        private _readyCheck(): void;
+
+        /*
+        BELOW IS DISCORD.JS COLLECTION CODE
+        Per notes in the LICENSE file, this project contains code from Amish Shah's Discord.js
+        library. The code is from the Collections object, in discord.js version 11.
+
+        All below code is sourced from Collections.
+        https://github.com/discordjs/discord.js/blob/stable/src/util/Collection.js
+        */
+
+        /**
+         * Creates an ordered array of the values of this Enmap.
          * The array will only be reconstructed if an item is added to or removed from the Enmap,
          * or if you change the length of the array itself. If you don't want this caching behaviour,
          * use `Array.from(enmap.values())` instead.
@@ -155,31 +460,29 @@ declare module 'enmap' {
         public array(): any[];
 
         /**
-         * Creates an ordered array of the keys of this Enmap, and caches it internally.
+         * Creates an ordered array of the keys of this Enmap
          * The array will only be reconstructed if an item is added to or removed from the Enmap,
          * or if you change the length of the array itself. If you don't want this caching behaviour,
          * use `Array.from(enmap.keys())` instead.
-         * @returns {Array}
+         * @returns {Array<string | number>}
          */
-        public keyArray(): any[];
+        keyArray(): key[];
 
         /**
-         * Obtains random value(s) from this Enmap. This relies on {@link Enmap#array},
-         * and thus the caching mechanism applies here as well.
+         * Obtains random value(s) from this Enmap. This relies on {@link Enmap#array}.
          * @param {number} [count] Number of values to obtain randomly
          * @returns {*|Array<*>} The single value if `count` is undefined,
          * or an array of values of `count` length
          */
-        public random(count: number): any | any[];
+        random(count?: number): any | any[];
 
         /**
-         * Obtains random key(s) from this Enmap. This relies on {@link Enmap#keyArray},
-         * and thus the caching mechanism applies here as well.
+         * Obtains random key(s) from this Enmap. This relies on {@link Enmap#keyArray}
          * @param {number} [count] Number of keys to obtain randomly
          * @returns {*|Array<*>} The single key if `count` is undefined,
          * or an array of keys of `count` length
          */
-        public randomKey(count: number): any | any[];
+        randomKey(count?: number): any | any[];
 
         /**
          * Searches for all items where their specified property's value is identical to the given value
@@ -190,7 +493,7 @@ declare module 'enmap' {
          * @example
          * enmap.findAll('username', 'Bob');
          */
-        public findAll(prop: string, value: any): any[];
+        findAll(prop: string, value: any): any[];
 
         /**
          * Searches for a single item where its specified property's value is identical to the given value
@@ -198,8 +501,7 @@ declare module 'enmap' {
          * [Array.find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find).
          * <warn>All Enmap used in Discord.js are mapped using their `id` property, and if you want to find by id you
          * should use the `get` method. See
-         * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get)
-         * for details.</warn>
+         * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get) for details.</warn>
          * @param {string|Function} propOrFn The property to test against, or the function to test with
          * @param {*} [value] The expected value - only applicable and required if using a property for the first argument
          * @returns {*}
@@ -208,37 +510,46 @@ declare module 'enmap' {
          * @example
          * enmap.find(val => val.username === 'Bob');
          */
-        public find(propOrFn: string | PropOrFun, value: any): any;
+        find(propOrFn: string | findFunc, value?: any): any;
 
+        /* eslint-disable max-len */
         /**
          * Searches for the key of a single item where its specified property's value is identical to the given value
          * (`item[prop] === value`), or the given function returns a truthy value. In the latter case, this is identical to
-         * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex
+         * [Array.findIndex()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex).
          * @param {string|Function} propOrFn The property to test against, or the function to test with
          * @param {*} [value] The expected value - only applicable and required if using a property for the first argument
-         * @returns {*}
+         * @returns {string|number}
          * @example
          * enmap.findKey('username', 'Bob');
          * @example
          * enmap.findKey(val => val.username === 'Bob');
          */
-        public findKey(propOrFn: string | PropOrFun, value: any): any;
+        /* eslint-enable max-len */
+        findKey(propOrFn: string | findKeyFunc, value?: any): key;
 
         /**
          * Searches for the existence of a single item where its specified property's value is identical to the given value
          * (`item[prop] === value`).
          * <warn>Do not use this to check for an item by its ID. Instead, use `enmap.has(id)`. See
-         * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has) for details.
-         * </warn>
+         * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has) for details.</warn>
          * @param {string} prop The property to test against
          * @param {*} value The expected value
          * @returns {boolean}
          * @example
          * if (enmap.exists('username', 'Bob')) {
-   *  console.log('user here!');
-   * }
+         *  console.log('user here!');
+         * }
          */
-        public exists(prop: string, value: any): boolean;
+        exists(prop: string, value: any): boolean;
+
+        /**
+         * Removes entries that satisfy the provided filter function.
+         * @param {Function} fn Function used to test (should return a boolean)
+         * @param {Object} [thisArg] Value to use as `this` when executing function
+         * @returns {number} The number of removed entries
+         */
+        sweep(fn: sweepFunc, thisArg?: any): number;
 
         /**
          * Identical to
@@ -248,7 +559,7 @@ declare module 'enmap' {
          * @param {Object} [thisArg] Value to use as `this` when executing function
          * @returns {Enmap}
          */
-        public filter(fn: filterFunc, thisArg?: any): Enmap;
+        filter(fn: filterFunc, thisArg?: any): Enmap;
 
         /**
          * Identical to
@@ -257,7 +568,17 @@ declare module 'enmap' {
          * @param {Object} [thisArg] Value to use as `this` when executing function
          * @returns {Array}
          */
-        public filterArray(fn: filterFunc, thisArg?: any): any[];
+        filterArray(fn: filterFunc, thisArg?: any): any[];
+
+        /**
+         * Partitions the collection into two collections where the first collection
+         * contains the items that passed and the second contains the items that failed.
+         * @param {Function} fn Function used to test (should return a boolean)
+         * @param {*} [thisArg] Value to use as `this` when executing function
+         * @returns {Collection[]}
+         * @example const [big, small] = collection.partition(guild => guild.memberCount > 250);
+         */
+        partition(fn: partitionFunc, thisArg?: any): [Enmap, Enmap];
 
         /**
          * Identical to
@@ -266,7 +587,7 @@ declare module 'enmap' {
          * @param {*} [thisArg] Value to use as `this` when executing function
          * @returns {Array}
          */
-        public map(fn: mapFunc, thisArg?: any): any[];
+        map(fn: mapFunc, thisArg?: any): any[];
 
         /**
          * Identical to
@@ -275,7 +596,7 @@ declare module 'enmap' {
          * @param {Object} [thisArg] Value to use as `this` when executing function
          * @returns {boolean}
          */
-        public some(fn: someFunc, thisArg?: any): any[];
+        some(fn: someFunc, thisArg?: any): boolean;
 
         /**
          * Identical to
@@ -284,7 +605,7 @@ declare module 'enmap' {
          * @param {Object} [thisArg] Value to use as `this` when executing function
          * @returns {boolean}
          */
-        public every(fn: everyFunc, thisArg?: any): any[];
+        every(fn: everyFunc, thisArg?: any): boolean;
 
         /**
          * Identical to
@@ -294,14 +615,14 @@ declare module 'enmap' {
          * @param {*} [initialValue] Starting value for the accumulator
          * @returns {*}
          */
-        public reduce(fn: reduceFunc, initialValue: any): any[];
+        reduce(fn: reduceFunc, initialValue: any): any;
 
         /**
          * Creates an identical shallow copy of this Enmap.
          * @returns {Enmap}
          * @example const newColl = someColl.clone();
          */
-        public clone(): Enmap;
+        clone(): Enmap;
 
         /**
          * Combines this Enmap with others into a new Enmap. None of the source Enmaps are modified.
@@ -309,22 +630,7 @@ declare module 'enmap' {
          * @returns {Enmap}
          * @example const newColl = someColl.concat(someOtherColl, anotherColl, ohBoyAColl);
          */
-        public concat(...enmaps: Enmap[]): Enmap;
-
-        /**
-         * Calls the `delete()` method on all items that have it.
-         * @param {boolean} bulk Optional. Defaults to True. whether to use the provider's "bulk" delete feature
-         * if it has one.
-         */
-        public deleteAll(bulk: boolean): void;
-
-        /**
-         * Calls the `delete()` method on all items that have it.
-         * @param {boolean} bulk Optional. Defaults to True. whether to use the provider's "bulk" delete feature
-         * if it has one.
-         * @return {Promise} Returns a promise that is resolved when the database is cleared.
-         */
-        public deleteAllAsync(bulk: boolean): Promise<any>;
+        concat(...enmaps: Enmap[]): Enmap;
 
         /**
          * Checks if this Enmap shares identical key-value pairings with another.
@@ -333,6 +639,6 @@ declare module 'enmap' {
          * @param {Enmap} enmap Enmap to compare with
          * @returns {boolean} Whether the Enmaps have identical contents
          */
-        public equals(enmap: Enmap): boolean;
+        equals(enmap: Enmap): boolean;
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -267,8 +267,8 @@ class Enmap extends Map {
 
   /**
    * Force fetch one or more key values from the enmap. If the database has changed, that new value is used.
-   * @param {string|number} keyOrKeys A single key or array of keys to force fetch from the enmap database.
-   * @return {Enmap} The Enmap, including the new fetched value(s).
+   * @param {string|number|Array<string|number>} keyOrKeys A single key or array of keys to force fetch from the enmap database.
+   * @return {Enmap|*} The Enmap, including the new fetched values, or the value in case the function argument is a single key.
    */
   fetch(keyOrKeys) {
     this[_readyCheck]();
@@ -288,7 +288,7 @@ class Enmap extends Map {
 
   /**
    * Removes a key or keys from the cache - useful when disabling autoFetch.
-   * @param {*} keyOrArrayOfKeys A single key or array of keys to remove from the cache.
+   * @param {string|number|Array<string|number>} keyOrArrayOfKeys A single key or array of keys to remove from the cache.
    * @returns {Enmap} The enmap minus the evicted keys.
    */
   evict(keyOrArrayOfKeys) {
@@ -306,7 +306,7 @@ class Enmap extends Map {
    * guarantee it's sequential (if a value is deleted, another can take its place).
    * Useful for logging, but not much else.
    * @example
-   * enmap.set(enmap.autonum(), "This is a new value");
+   * enmap.set(enmap.autonum, "This is a new value");
    * @return {number} The generated key number.
    */
   get autonum() {
@@ -346,7 +346,7 @@ class Enmap extends Map {
    * This is a shortcut to loading the key, changing the value, and setting it back.
    * @param {string|number} key Required. The key of the element to add to The Enmap or array.
    * This value MUST be a string or number.
-   * @param {*} path Required. The property to modify inside the value object or array.
+   * @param {string} path Required. The property to modify inside the value object or array.
    * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
    * @param {*} val Required. The value to apply to the specified property.
    * @returns {Enmap} The enmap.
@@ -395,7 +395,7 @@ class Enmap extends Map {
    * Push to an array element inside an Object or Array element in Enmap.
    * @param {string|number} key Required. The key of the element.
    * This value MUST be a string or number.
-   * @param {*} path Required. The name of the array property to push to.
+   * @param {string} path Required. The name of the array property to push to.
    * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
    * @param {*} val Required. The value push to the array property.
    * @param {boolean} allowDupes Allow duplicate values in the array (default: false).
@@ -427,7 +427,7 @@ class Enmap extends Map {
    * points.math("number", "modulo", 3); // 2
    * points.math("numberInObject", "+", 10, "sub.anInt");
    *
-   * @return {Map} The EnMap.
+   * @returns {Enmap} The enmap.
    */
   math(key, operation, operand, path = null) {
     this[_readyCheck]();
@@ -459,7 +459,7 @@ class Enmap extends Map {
    *
    * points.inc("number"); // 43
    * points.inc("numberInObject", "sub.anInt"); // {sub: { anInt: 6 }}
-   * @return {Map} The EnMap.
+   * @returns {Enmap} The enmap.
    */
   inc(key, path = null) {
     this[_readyCheck]();
@@ -486,7 +486,7 @@ class Enmap extends Map {
    *
    * points.dec("number"); // 41
    * points.dec("numberInObject", "sub.anInt"); // {sub: { anInt: 4 }}
-   * @return {Map} The EnMap.
+   * @returns {Enmap} The enmap.
    */
   dec(key, path = null) {
     this[_readyCheck]();
@@ -505,7 +505,7 @@ class Enmap extends Map {
   /**
    * Returns the specific property within a stored value. If the key does not exist or the value is not an object, throws an error.
    * @param {string|number} key Required. The key of the element to get from The Enmap.
-   * @param {*} path Required. The property to retrieve from the object or array.
+   * @param {string} path Required. The property to retrieve from the object or array.
    * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
    * @return {*} The value of the property obtained.
    */
@@ -624,7 +624,8 @@ class Enmap extends Map {
         if (this.polling) {
           this.db.prepare(`INSERT INTO 'internal::changes::${this.name}' (type, key, timestamp, pid) VALUES (?, ?, ?, ?);`).run('delete', key.toString(), Date.now(), process.pid);
         }
-        return this.db.prepare(`DELETE FROM ${this.name} WHERE key = '${key}'`).run();
+        this.db.prepare(`DELETE FROM ${this.name} WHERE key = '${key}'`).run();
+        return this;
       }
       if (typeof this.changedCB === 'function') {
         this.changedCB(key, oldValue, null);
@@ -636,7 +637,7 @@ class Enmap extends Map {
   /**
    * Delete a property from an object or array value in Enmap.
    * @param {string|number} key Required. The key of the element to delete the property from in Enmap.
-   * @param {*} path Required. The name of the property to remove from the object.
+   * @param {string} path Required. The name of the property to remove from the object.
    * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
    */
   deleteProp(key, path) {
@@ -671,7 +672,7 @@ class Enmap extends Map {
    * @param {string} path Optional. The name of the array property to remove from.
    * Can be a path with dot notation, such as "prop1.subprop2.subprop3".
    * If not presents, removes directly from the value.
-   * @return {Map} The EnMap.
+   * @returns {Enmap} The enmap.
    */
   remove(key, val, path = null) {
     this[_readyCheck]();
@@ -700,10 +701,10 @@ class Enmap extends Map {
    * Confusing? Sure is.
    * @param {string|number} key Required. The key of the element.
    * This value MUST be a string or number.
-   * @param {*} path Required. The name of the array property to remove from.
+   * @param {string} path Required. The name of the array property to remove from.
    * Can be a path with dot notation, such as "prop1.subprop2.subprop3"
    * @param {*} val Required. The value to remove from the array property.
-   * @return {Map} The EnMap.
+   * @returns {Enmap} The enmap.
    */
   removeFrom(key, path, val) {
     this[_readyCheck]();
@@ -952,22 +953,22 @@ class Enmap extends Map {
   }
 
   /**
-     * Creates an ordered array of the keys of this Enmap
-     * The array will only be reconstructed if an item is added to or removed from the Enmap,
-     * or if you change the length of the array itself. If you don't want this caching behaviour,
-     * use `Array.from(enmap.keys())` instead.
-     * @returns {Array}
-     */
+   * Creates an ordered array of the keys of this Enmap
+   * The array will only be reconstructed if an item is added to or removed from the Enmap,
+   * or if you change the length of the array itself. If you don't want this caching behaviour,
+   * use `Array.from(enmap.keys())` instead.
+   * @returns {Array<string | number>}
+   */
   keyArray() {
     return Array.from(this.keys());
   }
 
   /**
-     * Obtains random value(s) from this Enmap. This relies on {@link Enmap#array}.
-     * @param {number} [count] Number of values to obtain randomly
-     * @returns {*|Array<*>} The single value if `count` is undefined,
-     * or an array of values of `count` length
-     */
+   * Obtains random value(s) from this Enmap. This relies on {@link Enmap#array}.
+   * @param {number} [count] Number of values to obtain randomly
+   * @returns {*|Array<*>} The single value if `count` is undefined,
+   * or an array of values of `count` length
+   */
   random(count) {
     let arr = this.array();
     if (count === undefined) return arr[Math.floor(Math.random() * arr.length)];
@@ -981,11 +982,11 @@ class Enmap extends Map {
   }
 
   /**
-     * Obtains random key(s) from this Enmap. This relies on {@link Enmap#keyArray}
-     * @param {number} [count] Number of keys to obtain randomly
-     * @returns {*|Array<*>} The single key if `count` is undefined,
-     * or an array of keys of `count` length
-     */
+   * Obtains random key(s) from this Enmap. This relies on {@link Enmap#keyArray}
+   * @param {number} [count] Number of keys to obtain randomly
+   * @returns {*|Array<*>} The single key if `count` is undefined,
+   * or an array of keys of `count` length
+   */
   randomKey(count) {
     let arr = this.keyArray();
     if (count === undefined) return arr[Math.floor(Math.random() * arr.length)];
@@ -999,14 +1000,14 @@ class Enmap extends Map {
   }
 
   /**
-     * Searches for all items where their specified property's value is identical to the given value
-     * (`item[prop] === value`).
-     * @param {string} prop The property to test against
-     * @param {*} value The expected value
-     * @returns {Array}
-     * @example
-     * enmap.findAll('username', 'Bob');
-     */
+   * Searches for all items where their specified property's value is identical to the given value
+   * (`item[prop] === value`).
+   * @param {string} prop The property to test against
+   * @param {*} value The expected value
+   * @returns {Array}
+   * @example
+   * enmap.findAll('username', 'Bob');
+   */
   findAll(prop, value) {
     if (typeof prop !== 'string') throw new TypeError('Key must be a string.');
     if (typeof value === 'undefined') throw new Error('Value must be specified.');
@@ -1018,20 +1019,20 @@ class Enmap extends Map {
   }
 
   /**
-     * Searches for a single item where its specified property's value is identical to the given value
-     * (`item[prop] === value`), or the given function returns a truthy value. In the latter case, this is identical to
-     * [Array.find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find).
-     * <warn>All Enmap used in Discord.js are mapped using their `id` property, and if you want to find by id you
-     * should use the `get` method. See
-     * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get) for details.</warn>
-     * @param {string|Function} propOrFn The property to test against, or the function to test with
-     * @param {*} [value] The expected value - only applicable and required if using a property for the first argument
-     * @returns {*}
-     * @example
-     * enmap.find('username', 'Bob');
-     * @example
-     * enmap.find(val => val.username === 'Bob');
-     */
+   * Searches for a single item where its specified property's value is identical to the given value
+   * (`item[prop] === value`), or the given function returns a truthy value. In the latter case, this is identical to
+   * [Array.find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find).
+   * <warn>All Enmap used in Discord.js are mapped using their `id` property, and if you want to find by id you
+   * should use the `get` method. See
+   * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get) for details.</warn>
+   * @param {string|Function} propOrFn The property to test against, or the function to test with
+   * @param {*} [value] The expected value - only applicable and required if using a property for the first argument
+   * @returns {*}
+   * @example
+   * enmap.find('username', 'Bob');
+   * @example
+   * enmap.find(val => val.username === 'Bob');
+   */
   find(propOrFn, value) {
     if (typeof propOrFn === 'string') {
       if (typeof value === 'undefined') throw new Error('Value must be specified.');
@@ -1050,17 +1051,17 @@ class Enmap extends Map {
 
   /* eslint-disable max-len */
   /**
-     * Searches for the key of a single item where its specified property's value is identical to the given value
-     * (`item[prop] === value`), or the given function returns a truthy value. In the latter case, this is identical to
-     * [Array.findIndex()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex).
-     * @param {string|Function} propOrFn The property to test against, or the function to test with
-     * @param {*} [value] The expected value - only applicable and required if using a property for the first argument
-     * @returns {*}
-     * @example
-     * enmap.findKey('username', 'Bob');
-     * @example
-     * enmap.findKey(val => val.username === 'Bob');
-     */
+   * Searches for the key of a single item where its specified property's value is identical to the given value
+   * (`item[prop] === value`), or the given function returns a truthy value. In the latter case, this is identical to
+   * [Array.findIndex()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex).
+   * @param {string|Function} propOrFn The property to test against, or the function to test with
+   * @param {*} [value] The expected value - only applicable and required if using a property for the first argument
+   * @returns {string|number}
+   * @example
+   * enmap.findKey('username', 'Bob');
+   * @example
+   * enmap.findKey(val => val.username === 'Bob');
+   */
   /* eslint-enable max-len */
   findKey(propOrFn, value) {
     if (typeof propOrFn === 'string') {
@@ -1079,18 +1080,18 @@ class Enmap extends Map {
   }
 
   /**
-     * Searches for the existence of a single item where its specified property's value is identical to the given value
-     * (`item[prop] === value`).
-     * <warn>Do not use this to check for an item by its ID. Instead, use `enmap.has(id)`. See
-     * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has) for details.</warn>
-     * @param {string} prop The property to test against
-     * @param {*} value The expected value
-     * @returns {boolean}
-     * @example
-     * if (enmap.exists('username', 'Bob')) {
-     *  console.log('user here!');
-     * }
-     */
+   * Searches for the existence of a single item where its specified property's value is identical to the given value
+   * (`item[prop] === value`).
+   * <warn>Do not use this to check for an item by its ID. Instead, use `enmap.has(id)`. See
+   * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has) for details.</warn>
+   * @param {string} prop The property to test against
+   * @param {*} value The expected value
+   * @returns {boolean}
+   * @example
+   * if (enmap.exists('username', 'Bob')) {
+   *  console.log('user here!');
+   * }
+   */
   exists(prop, value) {
     return Boolean(this.find(prop, value));
   }
@@ -1111,13 +1112,13 @@ class Enmap extends Map {
   }
 
   /**
-     * Identical to
-     * [Array.filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter),
-     * but returns a Enmap instead of an Array.
-     * @param {Function} fn Function used to test (should return a boolean)
-     * @param {Object} [thisArg] Value to use as `this` when executing function
-     * @returns {Enmap}
-     */
+   * Identical to
+   * [Array.filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter),
+   * but returns a Enmap instead of an Array.
+   * @param {Function} fn Function used to test (should return a boolean)
+   * @param {Object} [thisArg] Value to use as `this` when executing function
+   * @returns {Enmap}
+   */
   filter(fn, thisArg) {
     if (thisArg) fn = fn.bind(thisArg);
     const results = new this.constructor();
@@ -1128,12 +1129,12 @@ class Enmap extends Map {
   }
 
   /**
-     * Identical to
-     * [Array.filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter).
-     * @param {Function} fn Function used to test (should return a boolean)
-     * @param {Object} [thisArg] Value to use as `this` when executing function
-     * @returns {Array}
-     */
+   * Identical to
+   * [Array.filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter).
+   * @param {Function} fn Function used to test (should return a boolean)
+   * @param {Object} [thisArg] Value to use as `this` when executing function
+   * @returns {Array}
+   */
   filterArray(fn, thisArg) {
     if (thisArg) fn = fn.bind(thisArg);
     const results = [];
@@ -1165,12 +1166,12 @@ class Enmap extends Map {
   }
 
   /**
-     * Identical to
-     * [Array.map()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map).
-     * @param {Function} fn Function that produces an element of the new array, taking three arguments
-     * @param {*} [thisArg] Value to use as `this` when executing function
-     * @returns {Array}
-     */
+   * Identical to
+   * [Array.map()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map).
+   * @param {Function} fn Function that produces an element of the new array, taking three arguments
+   * @param {*} [thisArg] Value to use as `this` when executing function
+   * @returns {Array}
+   */
   map(fn, thisArg) {
     if (thisArg) fn = fn.bind(thisArg);
     const arr = new Array(this.size);
@@ -1180,12 +1181,12 @@ class Enmap extends Map {
   }
 
   /**
-     * Identical to
-     * [Array.some()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some).
-     * @param {Function} fn Function used to test (should return a boolean)
-     * @param {Object} [thisArg] Value to use as `this` when executing function
-     * @returns {boolean}
-     */
+   * Identical to
+   * [Array.some()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some).
+   * @param {Function} fn Function used to test (should return a boolean)
+   * @param {Object} [thisArg] Value to use as `this` when executing function
+   * @returns {boolean}
+   */
   some(fn, thisArg) {
     if (thisArg) fn = fn.bind(thisArg);
     for (const [key, val] of this) {
@@ -1195,12 +1196,12 @@ class Enmap extends Map {
   }
 
   /**
-     * Identical to
-     * [Array.every()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every).
-     * @param {Function} fn Function used to test (should return a boolean)
-     * @param {Object} [thisArg] Value to use as `this` when executing function
-     * @returns {boolean}
-     */
+   * Identical to
+   * [Array.every()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every).
+   * @param {Function} fn Function used to test (should return a boolean)
+   * @param {Object} [thisArg] Value to use as `this` when executing function
+   * @returns {boolean}
+   */
   every(fn, thisArg) {
     if (thisArg) fn = fn.bind(thisArg);
     for (const [key, val] of this) {
@@ -1210,13 +1211,13 @@ class Enmap extends Map {
   }
 
   /**
-     * Identical to
-     * [Array.reduce()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce).
-     * @param {Function} fn Function used to reduce, taking four arguments; `accumulator`, `currentValue`, `currentKey`,
-     * and `enmap`
-     * @param {*} [initialValue] Starting value for the accumulator
-     * @returns {*}
-     */
+   * Identical to
+   * [Array.reduce()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce).
+   * @param {Function} fn Function used to reduce, taking four arguments; `accumulator`, `currentValue`, `currentKey`,
+   * and `enmap`
+   * @param {*} [initialValue] Starting value for the accumulator
+   * @returns {*}
+   */
   reduce(fn, initialValue) {
     let accumulator;
     if (typeof initialValue !== 'undefined') {
@@ -1237,20 +1238,20 @@ class Enmap extends Map {
   }
 
   /**
-     * Creates an identical shallow copy of this Enmap.
-     * @returns {Enmap}
-     * @example const newColl = someColl.clone();
-     */
+   * Creates an identical shallow copy of this Enmap.
+   * @returns {Enmap}
+   * @example const newColl = someColl.clone();
+   */
   clone() {
     return new this.constructor(this);
   }
 
   /**
-     * Combines this Enmap with others into a new Enmap. None of the source Enmaps are modified.
-     * @param {...Enmap} enmaps Enmaps to merge
-     * @returns {Enmap}
-     * @example const newColl = someColl.concat(someOtherColl, anotherColl, ohBoyAColl);
-     */
+   * Combines this Enmap with others into a new Enmap. None of the source Enmaps are modified.
+   * @param {...Enmap} enmaps Enmaps to merge
+   * @returns {Enmap}
+   * @example const newColl = someColl.concat(someOtherColl, anotherColl, ohBoyAColl);
+   */
   concat(...enmaps) {
     const newColl = this.clone();
     for (const coll of enmaps) {
@@ -1260,12 +1261,12 @@ class Enmap extends Map {
   }
 
   /**
-     * Checks if this Enmap shares identical key-value pairings with another.
-     * This is different to checking for equality using equal-signs, because
-     * the Enmaps may be different objects, but contain the same data.
-     * @param {Enmap} enmap Enmap to compare with
-     * @returns {boolean} Whether the Enmaps have identical contents
-     */
+   * Checks if this Enmap shares identical key-value pairings with another.
+   * This is different to checking for equality using equal-signs, because
+   * the Enmaps may be different objects, but contain the same data.
+   * @param {Enmap} enmap Enmap to compare with
+   * @returns {boolean} Whether the Enmaps have identical contents
+   */
   equals(enmap) {
     if (!enmap) return false;
     if (this === enmap) return true;


### PR DESCRIPTION
The index.d.ts file is currently outdated, it still includes the provider argument in the constructor for example. This PR fixes that.

Changes in the ./src/index.js file:
- Added missing types.
- Methods from D.JS Collections; Strange tab that I couldn't leave there.
- `fetch`; Documentation about the arguments and returning value are not complete.
- `autonum`; Is a getter, so no `()` in the example.
- `delete`; It didn't always return the Enmap like the documentation says.
- `@returns` jsdoc comment was not really consistent.

This PR does NOT include any changes to the working of Enmap in any way. It is only about the index.d.ts file for TypeScript support, and a few minor documentation improvements.