### PR TITLE
feat(Enmap): add options#wal (default true).

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ declare module "enmap" {
         polling?: boolean;
         pollingInterval?: number;
         ensureProps?: boolean;
+        wal?: boolean;
     };
 
     type MathOps =
@@ -62,6 +63,7 @@ declare module "enmap" {
         public readonly isReady: boolean;
         public readonly lastSync: Date;
         public readonly ensureProps: boolean;
+        public readonly wal: boolean;
         public readonly changedCB: (key: K, oldValue: V | undefined, newValue: V | undefined) => void;
 
         private db: any;

--- a/src/index.js
+++ b/src/index.js
@@ -35,27 +35,28 @@ class Enmap extends Map {
    * @param {iterable|string} iterable If iterable data, only valid in non-persistent enmaps.
    * If this parameter is a string, it is assumed to be the enmap's name, which is a shorthand for adding a name in the options
    * and making the enmap persistent.
-   * @param {Object} options Additional options for the enmap. See https://enmap.evie.codes/usage#enmap-options for details.
-   * @param {string} options.name The name of the enmap. Represents its table name in sqlite. If present, the enmap is persistent.
+   * @param {Object} [options] Additional options for the enmap. See https://enmap.evie.codes/usage#enmap-options for details.
+   * @param {string} [options.name] The name of the enmap. Represents its table name in sqlite. If present, the enmap is persistent.
    * If no name is given, the enmap is memory-only and is not saved in the database. As a shorthand, you may use a string for the name
    * instead of the options (see example).
-   * @param {boolean} options.fetchAll Defaults to `true`. When enabled, will automatically fetch any key that's requested using get,
+   * @param {boolean} [options.fetchAll] Defaults to `true`. When enabled, will automatically fetch any key that's requested using get,
    * getProp, etc. This is a "syncroneous" operation, which means it doesn't need any of this promise or callback use.
-   * @param {string} options.dataDir Defaults to `./data`. Determines where the sqlite files will be stored. Can be relative
+   * @param {string} [options.dataDir] Defaults to `./data`. Determines where the sqlite files will be stored. Can be relative
    * (to your project root) or absolute on the disk. Windows users , remember to escape your backslashes!
-   * @param {string} options.cloneLevel Defaults to deep. Determines how objects and arrays are treated when inserting and retrieving from the database.
+   * @param {string} [options.cloneLevel] Defaults to deep. Determines how objects and arrays are treated when inserting and retrieving from the database.
    * See https://enmap.evie.codes/usage#enmap-options for more details on this option.
-   * @param {boolean} options.polling defaults to `false`. Determines whether Enmap will attempt to retrieve changes from the database on a regular interval.
+   * @param {boolean} [options.polling] defaults to `false`. Determines whether Enmap will attempt to retrieve changes from the database on a regular interval.
    * This means that if another Enmap in another process modifies a value, this change will be reflected in ALL enmaps using the polling feature.
-   * @param {string} options.pollingInterval defaults to `1000`, polling every second. Delay in milliseconds to poll new data from the database.
+   * @param {string} [options.pollingInterval] defaults to `1000`, polling every second. Delay in milliseconds to poll new data from the database.
    * The shorter the interval, the more CPU is used, so it's best not to lower this. Polling takes about 350-500ms if no data is found, and time will
    * grow with more changes fetched. In my tests, 15 rows took a little more than 1 second, every second.
-   * @param {boolean} options.ensureProps defaults to `false`. If enabled and the value in the enmap is an object, using ensure() will also ensure that
+   * @param {boolean} [options.ensureProps] defaults to `false`. If enabled and the value in the enmap is an object, using ensure() will also ensure that
    * every property present in the default object will be added to the value, if it's absent. See ensure API reference for more information.
-   * @param {boolean} options.strictType defaults to `false`. If enabled, locks the enmap to the type of the first value written to it (such as Number or String or Object).
+   * @param {boolean} [options.strictType] defaults to `false`. If enabled, locks the enmap to the type of the first value written to it (such as Number or String or Object).
    * Do not enable this option if your enmap contains different types of value or the enmap will fail to load.
-   * @param {string} options.typeLock Only used if strictType is enabled. Defines an initial type for every value entered in the enmap. If no value is
+   * @param {string} [options.typeLock] Only used if strictType is enabled. Defines an initial type for every value entered in the enmap. If no value is
    * provided, the first value written to enmap will determine its typeLock. Must be a valid JS Primitive name, such as String, Number, Object, Array.
+   * @param {boolean} [options.wal=false] Check out Write-Ahead Logging: https://www.sqlite.org/wal.html
    * @example
    * const Enmap = require("enmap");
    * // Non-persistent enmap:
@@ -118,6 +119,7 @@ class Enmap extends Map {
       this[_defineSetting]('autoFetch', 'Boolean', true, true, options.autoFetch);
       this[_defineSetting]('ensureProps', 'Boolean', true, false, options.ensureProps);
       this[_defineSetting]('strictType', 'Boolean', true, false, options.strictType);
+      this[_defineSetting]('wal', 'Boolean', true, true, options.wal);
       Object.defineProperty(this, 'typeLock', {
         value: options.typeLock || null,
         writable: true,
@@ -885,7 +887,7 @@ class Enmap extends Map {
     if (!table['count(*)']) {
       this.db.prepare(`CREATE TABLE ${this.name} (key text PRIMARY KEY, value text)`).run();
       this.db.pragma('synchronous = 1');
-      this.db.pragma('journal_mode = wal');
+      if (this.wal) this.db.pragma('journal_mode = wal');
     }
     this.db.prepare(`CREATE TABLE IF NOT EXISTS 'internal::changes::${this.name}' (type TEXT, key TEXT, value TEXT, timestamp INTEGER, pid INTEGER);`).run();
     this.db.prepare(`CREATE TABLE IF NOT EXISTS 'internal::autonum' (enmap TEXT PRIMARY KEY, lastnum INTEGER)`).run();


### PR DESCRIPTION
The journal mode is always 'wal' on Enmap from the beginning. A user has to exchange these disadvantages for extremely fast performance in most web applications, however, what if a user would not prefer extremely fast speed over these drastic disadvantages:
- Transactions that involve ATTACHed databases are atomic for each individual database but are not atomic across all databases as a set.
- Under rare circumstances, the WAL file may experience "checkpoint starvation" (see below).
- There are some hardware/system limitations that may affect some users, listed here.

Checkpoint starvation: when SQLite3 is unable to recycle the WAL file due to everlasting concurrent reads to the database. If this happens, the WAL file will grow without bound, leading to unacceptable amounts of disk usage and deteriorating performance.
If you don't access the database from multiple processes simultaneously, you'll never encounter this issue.
If you do access the database from multiple processes simultaneously, just use the db.checkpoint() method when the WAL file gets too big.