### PR TITLE
refactor: remove the _ before defineSetting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const _parseData = Symbol('parseData');
 const _readyCheck = Symbol('readyCheck');
 const _clone = Symbol('clone');
 const _init = Symbol('init');
-const _defineSetting = Symbol('_defineSetting');
+const _defineSetting = Symbol('defineSetting');
 
 /**
  * A enhanced Map structure with additional utility methods.


### PR DESCRIPTION
Remove the underscore (_) before 'defineSetting' variable, due to the convention