### PR TITLE
typings(EnmapOptions): change type alias to exported interface

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,5 @@
 declare module "enmap" {
-    type EnmapOptions = {
+    export interface EnmapOptions {
         name?: string;
         fetchAll?: boolean;
         autoFetch?: boolean;


### PR DESCRIPTION
This PR changes EnmapOptions from a type alias to an interface and exports it.

Reasoning: in TypeScript, TypeErrors relating to a type alias throw obscure messages, while those relating to an interface provide the name of the interface. Additionally, interfaces can be extended, allowing users to build custom options on top of the built-in ones. Exporting the interface enables this extensibility.