### PR TITLE
Removed type restriction on set function with JSON.stringify

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -249,15 +249,9 @@ class Enmap extends Map {
    * @returns {Enmap} The enmap.
    */
   set(key, val, path = null) {
-    if (isNil(key) || key.constructor.name !== 'String') {
-      throw new Err(
-        `Enmap requires keys to be a string. Provided: ${
-          isNil(key) ? 'nil' : key.constructor.name
-        }`,
-        'EnmapKeyTypeError',
-      );
-    }
-    key = key.toString();
+    if (typeof key !== 'string') {
+      key = JSON.stringify(key)
+    } 
     let data = this.get(key);
     const oldValue = super.has(key) ? this[_clone](data) : null;
     if (!isNil(path)) {


### PR DESCRIPTION
This PR was inspired by #66 Although that PR had a mistake in which Objects when being converted to string using .toString() returned [object Object]. This PR fixes this issue.