### PR TITLE
bugfix: import deseralization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -887,7 +887,7 @@ class Enmap extends Map {
       for (const thisEntry of parsed.keys) {
         const { key, value } = thisEntry;
         if (!overwrite && this.has(key)) continue;
-        this[_internalSet](key, value);
+        this[_internalSet](key, this.deserializer(value, key));
       }
     } catch (err) {
       throw new Err(


### PR DESCRIPTION
Import was not deseralizing the seralized imported data, causing it to get the data seralized again in internal set.