### PR TITLE
fix: do not create an unlimited number of event handlers on exit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,9 +42,8 @@ const _internalSet = Symbol('_internalSet');
 
 // In order to prevent an unrestricted number of event listeners on Process, we create the listeners here
 // to close the database on exit.
-const _instances = [];
 process.on('exit', () => {
-  for (let instance of _instances) {
+  for (let instance of Enmap._instances) {
     instance.db.close();
   }
 });
@@ -55,6 +54,9 @@ process.on('exit', () => {
  * @extends {Map}
  */
 class Enmap extends Map {
+  /** Stores all of the Enmap instances to be removed on close. */
+  static _instances;
+  
   /**
    * Initializes a new Enmap, with options.
    * @param {iterable|string} iterable If iterable data, only valid in non-persistent enmaps.
@@ -238,7 +240,7 @@ class Enmap extends Map {
     }
 
     // To allow us to clean up on process exit.
-    _instances.push(this);
+    Enmap._instances.push(this);
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,15 @@ const _init = Symbol('init');
 const _defineSetting = Symbol('_defineSetting');
 const _internalSet = Symbol('_internalSet');
 
+// In order to prevent an unrestricted number of event listeners on Process, we create the listeners here
+// to close the database on exit.
+const _instances = [];
+process.on('exit', () => {
+  for (let instance of _instances) {
+    instance.db.close();
+  }
+});
+
 /**
  * A enhanced Map structure with additional utility methods.
  * Can be made persistent
@@ -228,11 +237,8 @@ class Enmap extends Map {
       }
     }
 
-    const _this = this; // Because Node can be fucking stupid sometimes
-    process.on('exit', () => {
-      // Cleanup the database before exiting.
-      _this.db.close();
-    });
+    // To allow us to clean up on process exit.
+    _instances.push(this);
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -43,8 +43,9 @@ const _internalSet = Symbol('_internalSet');
 // In order to prevent an unrestricted number of event listeners on Process, we create the listeners here
 // to close the database on exit.
 process.on('exit', () => {
-  for (let instance of Enmap._instances) {
-    instance.db.close();
+  while (Enmap._instances[0]) {
+    Enmap._instances[0].db.close();
+    Enmap._instances.shift();
   }
 });
 


### PR DESCRIPTION
the `process` event emitter likes to only have 10 listeners or it pushes a memory leak warning; my bot has like 6 enmaps filling up most of those spaces so i get a warning

it can be bypassed but that's not recommended so here's an idea...