### PR TITLE
Update Typescript types to include import and export

### DIFF
--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -507,7 +507,7 @@ enmap.remove('objectarray', (value) => value.e === 5); // value is now [{ a: 1, 
 <a name="Enmap+export"></a>
 
 ### enmap.export() ⇒ <code>string</code>
-Exports the enmap data to a JSON file.
+Exports the enmap data to stringified JSON format.
 **__WARNING__**: Does not work on memory enmaps containing complex data!
 
 **Kind**: instance method of [<code>Enmap</code>](#enmap-map)  

--- a/src/index.js
+++ b/src/index.js
@@ -156,15 +156,15 @@ class Enmap extends Map {
       this.#db = new Database(':memory:', { verbose: this.#verbose });
       this.#name = 'MemoryEnmap';
     }
-    
+
     if (this.#polling) {
       process.emitWarning(
         'Polling features will be removed in Enmap v6. If you need enmap in multiple processes, please consider moving to JOSH, https://josh.evie.dev/',
-        );
-      }
-      
-      // Initialize this property, to prepare for a possible destroy() call.
-      // This is completely ignored in all situations except destroying the enmap.
+      );
+    }
+
+    // Initialize this property, to prepare for a possible destroy() call.
+    // This is completely ignored in all situations except destroying the enmap.
     this.#validateName();
     this.#isDestroyed = false;
     this.#init(this.#db);
@@ -820,7 +820,7 @@ class Enmap extends Map {
   }
 
   /**
-   * Exports the enmap data to a JSON file.
+   * Exports the enmap data to stringified JSON format.
    * **__WARNING__**: Does not work on memory enmaps containing complex data!
    * @returns {string} The enmap data in a stringified JSON format.
    */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -476,7 +476,7 @@ declare module 'enmap' {
     public removeFrom(key: K, path: string, val: any): this;
 
     /**
-     * Exports the enmap data to a string. WARNING: Does not work on memory enmaps containing complex data!
+     * Exports the enmap data to stringified JSON format. WARNING: Does not work on memory enmaps containing complex data!
      * @returns The enmap data in a stringified JSON format.
      */
     public export(): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -476,6 +476,21 @@ declare module 'enmap' {
     public removeFrom(key: K, path: string, val: any): this;
 
     /**
+     * Exports the enmap data to a JSON file. WARNING: Does not work on memory enmaps containing complex data!
+     * @returns The enmap data in a stringified JSON format.
+     */
+    public export(): string;
+
+    /**
+     * Import an existing json export from enmap from a string. This data must have been exported from enmap, and must be from a version that's equivalent or lower than where you're importing it.
+     * @param data The data to import to Enmap. Must contain all the required fields provided by export()
+     * @param overwrite Defaults to true. Whether to overwrite existing key/value data with incoming imported data
+     * @param clear Defaults to false. Whether to clear the enmap of all data before importing (WARNING: Any exiting data will be lost! This cannot be undone.)
+     * @returns The enmap.
+     */
+    public import(data: string, overwrite?: boolean, clear?: boolean): this;
+
+    /**
      * Initialize multiple Enmaps easily.
      * @param names Array of strings. Each array entry will create a separate enmap with that name.
      * @param options Options object to pass to the provider. See provider documentation for its options.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -476,7 +476,7 @@ declare module 'enmap' {
     public removeFrom(key: K, path: string, val: any): this;
 
     /**
-     * Exports the enmap data to a JSON file. WARNING: Does not work on memory enmaps containing complex data!
+     * Exports the enmap data to a string. WARNING: Does not work on memory enmaps containing complex data!
      * @returns The enmap data in a stringified JSON format.
      */
     public export(): string;


### PR DESCRIPTION
The types for import and export were missing from the Typescript definitions.