### PR TITLE
Add inMemory to EnmapOptions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -11,6 +11,7 @@ declare module 'enmap' {
     wal?: boolean;
     verbose?: (query: string) => void;
     autoEnsure?: unknown;
+    inMemory?: boolean;
     serializer?: (value: V, key: string) => SV;
     deserializer?: (value: SV, key: string) => V;
   }


### PR DESCRIPTION
This variable in the EnmapOptions interface is missing, causing an error in the constructor. As per the docs, defaults to false but can be specified when instantiating a new Enmap instance.