### PR TITLE
fix `has` and use `undefined` instead of `null`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -255,7 +255,7 @@ export default class Enmap<V = any, SV = unknown> {
   /**
    * Returns whether or not the key exists in the Enmap.
    * @param {string} key Required. The key of the element to add to The Enmap or array.
-   * @param {string} path Optional. The name of the property to check inside the object or array.
+   * @param {Path<V>} path Optional. The name of the property to check inside the object or array.
    * Should be a path with dot notation, such as "prop1.subprop2.subprop3"
    * @example
    * if(enmap.has("myKey")) {
@@ -265,7 +265,7 @@ export default class Enmap<V = any, SV = unknown> {
    * if(!enmap.has("myOtherKey", "oneProp.otherProp.SubProp")) return false;
    * @returns {boolean}
    */
-  has(key: string, path?: string): boolean {
+  has(key: string, path?: Path<V>): boolean {
     this.#keycheck(key);
     
     // Check if the key exists

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,10 +229,10 @@ export default class Enmap<V = any, SV = unknown> {
    *
    * const someSubValue = enmap.get("anObjectKey", "someprop.someOtherSubProp");
    */
-  get(key: string): V | null;
-  get<P extends Path<V>>(key: string, path: P): PathValue<V, P> | null;
-  get<P extends Path<V>>(key: string, path: P | undefined): V | PathValue<V, P> | null;
-  get<P extends Path<V>>(key: string, path?: P): V | PathValue<V, P> | null {
+  get(key: string): V | undefined;
+  get<P extends Path<V>>(key: string, path: P): PathValue<V, P> | undefined;
+  get<P extends Path<V>>(key: string, path: P | undefined): V | PathValue<V, P> | undefined;
+  get<P extends Path<V>>(key: string, path?: P): V | PathValue<V, P> | undefined {
     this.#keycheck(key);
 
     if (!isNil(this.#autoEnsure) && !this.has(key)) {
@@ -242,8 +242,8 @@ export default class Enmap<V = any, SV = unknown> {
     const data = this.#db
       .prepare(`SELECT value FROM ${this.#name}  WHERE key = ?`)
       .get(key) as { value: string } | undefined;
-    const parsed = data ? this.#parse(data.value, key) : null;
-    if (isNil(parsed)) return null;
+    const parsed = data ? this.#parse(data.value, key) : undefined;
+    if (isNil(parsed)) return undefined;
 
     if (path) {
       this.#check(key, ['Object']);
@@ -508,7 +508,7 @@ export default class Enmap<V = any, SV = unknown> {
     operation: MathOps,
     operand: number,
     path?: Path<V>,
-  ): number | null {
+  ): number | undefined {
     this.#keycheck(key);
     this.#check(key, ['Number'], path);
     const data = this.get(key, path);
@@ -580,17 +580,17 @@ export default class Enmap<V = any, SV = unknown> {
    * console.log(settings) // enmap's value for "1234567890" if it exists, otherwise the defaultSettings value.
    * @return {*} The value from the database for the key, or the default value provided for a new key.
    */
-  ensure(key: string, defaultValue: any): V | null;
+  ensure(key: string, defaultValue: any): V | undefined;
   ensure<P extends Path<V>>(
     key: string,
     defaultValue: any,
     path: P,
-  ): PathValue<V, P> | null;
+  ): PathValue<V, P> | undefined;
   ensure<P extends Path<V>>(
     key: string,
     defaultValue: any,
     path?: P,
-  ): V | PathValue<V, P> | null {
+  ): V | PathValue<V, P> | undefined {
     this.#keycheck(key);
 
     if (!isNil(this.#autoEnsure)) {
@@ -911,7 +911,7 @@ export default class Enmap<V = any, SV = unknown> {
   find(
     pathOrFn: ((val: V, key: string) => boolean) | string,
     value?: any,
-  ): V | null {
+  ): V | undefined {
     const stmt = this.#db.prepare(`SELECT key, value FROM ${this.#name}`);
     for (const row of stmt.iterate() as IterableIterator<{
       key: string;
@@ -925,7 +925,7 @@ export default class Enmap<V = any, SV = unknown> {
         return parsed;
       }
     }
-    return null;
+    return undefined;
   }
 
   /**
@@ -943,7 +943,7 @@ export default class Enmap<V = any, SV = unknown> {
   findIndex(
     pathOrFn: ((val: V, key: string) => boolean) | string,
     value?: any,
-  ): string | null {
+  ): string | undefined {
     const stmt = this.#db.prepare(`SELECT key, value FROM ${this.#name}`);
     for (const row of stmt.iterate() as IterableIterator<{
       key: string;
@@ -957,7 +957,7 @@ export default class Enmap<V = any, SV = unknown> {
         return row.key;
       }
     }
-    return null;
+    return undefined;
   }
 
   /**
@@ -1207,7 +1207,7 @@ export default class Enmap<V = any, SV = unknown> {
     }
   }
 
-  #math(base: number, op: MathOps, opand: number): number | null {
+  #math(base: number, op: MathOps, opand: number): number | undefined {
     if (base == undefined || op == undefined || opand == undefined)
       throw new Err(
         'Math Operation requires base and operation',
@@ -1242,6 +1242,6 @@ export default class Enmap<V = any, SV = unknown> {
       case 'random':
         return Math.floor(Math.random() * Math.floor(opand));
     }
-    return null;
+    return undefined;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,19 +254,35 @@ export default class Enmap<V = any, SV = unknown> {
 
   /**
    * Returns whether or not the key exists in the Enmap.
-   * @param key Required. The key of the element to add to The Enmap or array.
+   * @param {string} key Required. The key of the element to add to The Enmap or array.
+   * @param {string} path Optional. The name of the property to check inside the object or array.
+   * Should be a path with dot notation, such as "prop1.subprop2.subprop3"
    * @example
    * if(enmap.has("myKey")) {
    *   // key is there
    * }
+   *
+   * if(!enmap.has("myOtherKey", "oneProp.otherProp.SubProp")) return false;
    * @returns {boolean}
    */
-  has(key: string): boolean {
+  has(key: string, path?: string): boolean {
     this.#keycheck(key);
+    
+    // Check if the key exists
     const data = this.#db
       .prepare(`SELECT count(*) FROM ${this.#name} WHERE key = ?`)
       .get(key) as { 'count(*)': number };
-    return data['count(*)'] > 0;
+    
+    if (data['count(*)'] === 0) return false;
+    
+    // If path is provided, check if the path exists within the value
+    if (path) {
+      this.#check(key, ['Object']);
+      const value = this.get(key);
+      return _get(value, path) !== undefined;
+    }
+    
+    return true;
   }
 
   /**

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -484,6 +484,12 @@ describe('Enmap', () => {
         expect(enmap.has('has')).toBe(true);
       });
 
+      test('should return true if key and path exists', () =>{
+        enmap.set('hasPath', 'value', 'nested');
+
+        expect(enmap.has('hasPath', 'nested')).toBe(true);
+      });
+
       test("should return false if key doesn't exist", () => {
         expect(enmap.has('unknown')).toBe(false);
       });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -107,10 +107,10 @@ describe('Enmap', () => {
         expect(enmap.get('setNumber')).toBe(1);
       });
 
-      test('should set a value w/ null', () => {
-        enmap.set('setNull', null);
+      test('should set a value w/ undefined', () => {
+        enmap.set('setNull', undefined);
 
-        expect(enmap.get('setNull')).toBe(null);
+        expect(enmap.get('setNull')).toBe(undefined);
       });
 
       test('should set a value w/ boolean', () => {
@@ -380,7 +380,7 @@ describe('Enmap', () => {
         enmap.set('huh', 1);
         enmap.math('huh', 'huh', 1);
 
-        expect(enmap.get('huh')).toBe(null);
+        expect(enmap.get('huh')).toBe(undefined);
       });
 
       test('should math value w/ path', () => {
@@ -512,7 +512,7 @@ describe('Enmap', () => {
         enmap.set('delete', 'value');
         enmap.delete('delete');
 
-        expect(enmap.get('delete')).toBe(null);
+        expect(enmap.get('delete')).toBe(undefined);
       });
 
       test('should delete a path', () => {
@@ -530,7 +530,7 @@ describe('Enmap', () => {
         enmap.set('clear', 'value');
         enmap.clear();
 
-        expect(enmap.get('clear')).toBe(null);
+        expect(enmap.get('clear')).toBe(undefined);
       });
     });
 
@@ -827,11 +827,11 @@ describe('Enmap', () => {
         expect(enmap.find('sub', 'value')).toEqual({ sub: 'value' });
       });
 
-      test('should return null if not found', () => {
+      test('should return undefined if not found', () => {
         enmap.set('find', 'value');
         enmap.set('find2', 'value2');
 
-        expect(enmap.find((val) => val === 'value3')).toBe(null);
+        expect(enmap.find((val) => val === 'value3')).toBe(undefined);
       });
     });
 
@@ -852,11 +852,11 @@ describe('Enmap', () => {
         expect(enmap.findIndex('sub', 'value')).toBe('find');
       });
 
-      test('should return null if not found', () => {
+      test('should return undefined if not found', () => {
         enmap.set('find', 'value');
         enmap.set('find2', 'value2');
 
-        expect(enmap.findIndex((val) => val === 'value3')).toBe(null);
+        expect(enmap.findIndex((val) => val === 'value3')).toBe(undefined);
       });
     });
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -493,6 +493,16 @@ describe('Enmap', () => {
       test("should return false if key doesn't exist", () => {
         expect(enmap.has('unknown')).toBe(false);
       });
+
+      test("Should return false if the subkey doesn't exists", () => {
+        enmap.set('hasPath2', undefined, 'nested');
+        expect(enmap.has('hasPath2', 'nested')).toBe(false);
+      });
+
+      test("should return false if key exists but path doesn't", () => {
+        enmap.set('hasPath3', 'value', 'nested');
+        expect(enmap.has('hasPath3', 'other')).toBe(false);
+      });
     });
 
     describe('includes', () => {


### PR DESCRIPTION
As discussed on the discord:
1. Before 6.1.5, the library return `undefined` when a value was not found/present. I created my bots (I use enmap on each! Great works!) around this because I use a lot optional (`x?: string`) that leads to strictly `undefined`. Typescript doesn't allow to set `undefined = null` like in Javascript. It leads to a breaking change in my base so... I changed the value returned.
2. `has` doesn't work in 6.1.5 and `path` was not accepted: 
```ts
import Enmap from "enmap";

interface MyServerData {
    language: string;
    welcomeMessage: string;
    otherSettings?: {
        moderator: string;
        notificationsEnabled: boolean;
    }
}

const database: Enmap<MyServerData> = new Enmap({
    name: "myServerData",
});

database.set("server123", {
    language: "en",
    welcomeMessage: "Welcome to the server!",
    otherSettings: {
        moderator: "adminUser",
        notificationsEnabled: true,
    }
})

database.set("server123", "fr", "language");
const key = database.get("server123", "language");
const otherSettings = database.get("server123", "otherSettings.moderator");
const welcomeMessage = database.get("server123", "welcomeMessage");
const k = database.has("server123.welcomeMessage");
console.log(`Welcome Message: ${welcomeMessage} | Present: ${k}`);
```

Result: `Welcome Message: Welcome to the server! | Present: false`
